### PR TITLE
Use Defer and Followup plus improve command descriptions

### DIFF
--- a/src/Magus.Bot/Magus.Bot.csproj
+++ b/src/Magus.Bot/Magus.Bot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<Version>1.2.4</Version>
+		<Version>1.2.5</Version>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>

--- a/src/Magus.Bot/Magus.Bot.csproj
+++ b/src/Magus.Bot/Magus.Bot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<Version>1.2.5</Version>
+		<Version>1.2.6</Version>
 		<OutputType>Exe</OutputType>
 		<TargetFramework>net6.0</TargetFramework>
 		<Nullable>enable</Nullable>

--- a/src/Magus.Bot/Modules/InfoModule.cs
+++ b/src/Magus.Bot/Modules/InfoModule.cs
@@ -7,7 +7,7 @@ using Magus.Data.Models.Embeds;
 
 namespace Magus.Bot.Modules
 {
-    [Group("info", "Information commands")]
+    [Group("info", "Get information about specific heroes, abilities, and items.")]
     [ModuleRegistration(Location.GLOBAL)]
     public class InfoModule : ModuleBase
     {
@@ -18,7 +18,7 @@ namespace Magus.Bot.Modules
             _db = db;
         }
 
-        [SlashCommand("hero", "I don't need an oracle to know you're not searching for Oracle")]
+        [SlashCommand("hero", "Get information about a hero; including abilities, vision range, stat base+gain, and more.")]
         public async Task InfoHero([Summary(description: "The heroes name to lookup")][Autocomplete(typeof(HeroAutocompleteHandler))] string name,
                                    [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
@@ -44,7 +44,7 @@ namespace Magus.Bot.Modules
                 await FollowupAsync($"Could not find an ability called **{name}**", ephemeral: true);
         }
 
-        [SlashCommand("scepter", "what does Aghanim's Scepter do for this hero?")]
+        [SlashCommand("scepter", "What does Aghanim's Scepter do for this hero?")]
         public async Task InfoScepter([Summary(description: "The heroes name to lookup")][Autocomplete(typeof(HeroAutocompleteHandler))] string name,
                                       [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
@@ -63,7 +63,7 @@ namespace Magus.Bot.Modules
                 await FollowupAsync($"Could not find an scepter for the hero called **{name}**", ephemeral: true);
         }
 
-        [SlashCommand("shard", "what does Aghanim's Shard do for this hero?")]
+        [SlashCommand("shard", "What does Aghanim's Shard do for this hero?")]
         public async Task InfoShard([Summary(description: "The heroes name to lookup")][Autocomplete(typeof(HeroAutocompleteHandler))] string name,
                                       [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
@@ -82,7 +82,7 @@ namespace Magus.Bot.Modules
                 await FollowupAsync($"Could not find an shard for the hero called **{name}**", ephemeral: true);
         }
 
-        [SlashCommand("item", "> I need 2211 gold for this and buyback!")]
+        [SlashCommand("item", "Get information about an item.")]
         public async Task InfoItem([Summary(description: "The items name to lookup")][Autocomplete(typeof(ItemAutocompleteHandler))] string name,
                                    [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {

--- a/src/Magus.Bot/Modules/InfoModule.cs
+++ b/src/Magus.Bot/Modules/InfoModule.cs
@@ -22,72 +22,77 @@ namespace Magus.Bot.Modules
         public async Task InfoHero([Summary(description: "The heroes name to lookup")][Autocomplete(typeof(HeroAutocompleteHandler))] string name,
                                    [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
+            await DeferAsync();
             var heroInfo = (await _db.GetEntityInfo<HeroInfoEmbed>(name, locale ?? Context.Interaction.UserLocale, 1)).FirstOrDefault();
 
             if (heroInfo != null)
-                await RespondAsync(embed: heroInfo.Embed.CreateDiscordEmbed());
+                await FollowupAsync(embed: heroInfo.Embed.CreateDiscordEmbed());
             else
-                await RespondAsync($"Could not find a hero called **{name}**", ephemeral: true);
+                await FollowupAsync($"Could not find a hero called **{name}**", ephemeral: true);
         }
 
         [SlashCommand("ability", "Ahh. How does this one work?")]
         public async Task InfoAbility([Summary(description: "The abilities name to lookup")][Autocomplete(typeof(AbilityAutocompleteHandler))] string name,
                                       [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
+            await DeferAsync();
             var abilityInfo = (await _db.GetEntityInfo<AbilityInfoEmbed>(name, locale ?? Context.Interaction.UserLocale, 1)).FirstOrDefault();
 
             if (abilityInfo != null)
-                await RespondAsync(embed: abilityInfo.Embed.CreateDiscordEmbed());
+                await FollowupAsync(embed: abilityInfo.Embed.CreateDiscordEmbed());
             else
-                await RespondAsync($"Could not find an ability called **{name}**", ephemeral: true);
+                await FollowupAsync($"Could not find an ability called **{name}**", ephemeral: true);
         }
 
         [SlashCommand("scepter", "what does Aghanim's Scepter do for this hero?")]
         public async Task InfoScepter([Summary(description: "The heroes name to lookup")][Autocomplete(typeof(HeroAutocompleteHandler))] string name,
                                       [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
+            await DeferAsync();
             var heroInfo = (await _db.GetEntityInfo<HeroInfoEmbed>(name, locale ?? Context.Interaction.UserLocale, 1)).FirstOrDefault();
             if (heroInfo == null)
             {
-                await RespondAsync($"Could not find an scepter for the hero called **{name}**", ephemeral: true);
+                await FollowupAsync($"Could not find an scepter for the hero called **{name}**", ephemeral: true);
                 return;
             }
 
             var abilityInfo = await _db.GetHeroScepter(heroInfo.EntityId, locale ?? Context.Interaction.UserLocale);
             if (abilityInfo != null)
-                await RespondAsync(embed: abilityInfo.Embed.CreateDiscordEmbed());
+                await FollowupAsync(embed: abilityInfo.Embed.CreateDiscordEmbed());
             else
-                await RespondAsync($"Could not find an scepter for the hero called **{name}**", ephemeral: true);
+                await FollowupAsync($"Could not find an scepter for the hero called **{name}**", ephemeral: true);
         }
 
         [SlashCommand("shard", "what does Aghanim's Shard do for this hero?")]
         public async Task InfoShard([Summary(description: "The heroes name to lookup")][Autocomplete(typeof(HeroAutocompleteHandler))] string name,
                                       [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
+            await DeferAsync();
             var heroInfo = (await _db.GetEntityInfo<HeroInfoEmbed>(name, locale ?? Context.Interaction.UserLocale, 1)).FirstOrDefault();
             if (heroInfo == null)
             {
-                await RespondAsync($"Could not find an shard for the hero called **{name}**", ephemeral: true);
+                await FollowupAsync($"Could not find an shard for the hero called **{name}**", ephemeral: true);
                 return;
             }
 
             var abilityInfo = await _db.GetHeroShard(heroInfo.EntityId, locale ?? Context.Interaction.UserLocale);
             if (abilityInfo != null)
-                await RespondAsync(embed: abilityInfo.Embed.CreateDiscordEmbed());
+                await FollowupAsync(embed: abilityInfo.Embed.CreateDiscordEmbed());
             else
-                await RespondAsync($"Could not find an shard for the hero called **{name}**", ephemeral: true);
+                await FollowupAsync($"Could not find an shard for the hero called **{name}**", ephemeral: true);
         }
 
         [SlashCommand("item", "> I need 2211 gold for this and buyback!")]
         public async Task InfoItem([Summary(description: "The items name to lookup")][Autocomplete(typeof(ItemAutocompleteHandler))] string name,
                                    [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
+            await DeferAsync();
             var itemInfo = (await _db.GetEntityInfo<ItemInfoEmbed>(name, locale ?? Context.Interaction.UserLocale)).FirstOrDefault();
 
             if (itemInfo != null)
-                await RespondAsync(embed: itemInfo.Embed.CreateDiscordEmbed());
+                await FollowupAsync(embed: itemInfo.Embed.CreateDiscordEmbed());
             else
-                await RespondAsync($"Could not find an item called **{name}**", ephemeral: true);
+                await FollowupAsync($"Could not find an item called **{name}**", ephemeral: true);
         }
     }
 }

--- a/src/Magus.Bot/Modules/ManagementModule.cs
+++ b/src/Magus.Bot/Modules/ManagementModule.cs
@@ -29,6 +29,13 @@ namespace Magus.Bot.Modules
             _botSettings = botSettings.Value;
         }
 
+        [SlashCommand("set-status", "playing, watching; whatever")]
+        public async Task SetStatus(string status, [Summary(description: "Can't be CustomStatus")] ActivityType type, [Summary(description: "If streaming, the url")] string? url = null)
+        {
+            await Context.Client.SetGameAsync(name: status, streamUrl: url, type: type);
+            await RespondAsync("Done", ephemeral: true);
+        }
+
         [Group(SubGroupName, "get info of things")]
         public class InfoGroup : InteractionModuleBase<SocketInteractionContext>
         {

--- a/src/Magus.Bot/Modules/MetaModule.cs
+++ b/src/Magus.Bot/Modules/MetaModule.cs
@@ -25,6 +25,7 @@ namespace Magus.Bot.Modules
         [SlashCommand("about", "What is MagusBot?")]
         public async Task About()
         {
+            await DeferAsync();
             var latestPatchNote = await _db.GetLatestPatch();
             var latestPatch = $"[{latestPatchNote.PatchNumber}](https://www.dota2.com/patches/{latestPatchNote.PatchNumber}) - <t:{latestPatchNote.Timestamp}:R>";
             var response = new EmbedBuilder()
@@ -44,25 +45,28 @@ namespace Magus.Bot.Modules
             response.AddField("Links", links, false);
             response.AddField(Emotes.Spacer.ToString(), "Dota and the Dota Logo are trademarks and/or registered trademarks of Valve Corporation");
 
-            await RespondAsync(embed: response.Build(), ephemeral: true);
+            await FollowupAsync(embed: response.Build(), ephemeral: true);
         }
 
         [SlashCommand("invite", "Where shall I go next? Ultimyr University? Yama Raskav? Hmm.")]
         public async Task Invite()
         {
-            await RespondAsync(text: "Share me with your friends (or server admin) with my invite link!\n" + _config.BotInvite);
+            await DeferAsync();
+            await FollowupAsync(text: "Share me with your friends (or server admin) with my invite link!\n" + _config.BotInvite);
         }
 
         [SlashCommand("privacy", "Privacy Policy for MagusBot")]
         public async Task Privacy()
         {
-            await RespondAsync(text: "To view the privacy policy for MagusBot, please follow the link below:\n" + _config.BotPrivacyPolicy);
+            await DeferAsync();
+            await FollowupAsync(text: "To view the privacy policy for MagusBot, please follow the link below:\n" + _config.BotPrivacyPolicy);
         }
 
         [SlashCommand("terms", "Terms of Service for MagusBot")]
         public async Task Term()
         {
-            await RespondAsync(text: "To view the terms of service for MagusBot, please follow the link below:\n" + _config.BotTermsOfService);
+            await DeferAsync();
+            await FollowupAsync(text: "To view the terms of service for MagusBot, please follow the link below:\n" + _config.BotTermsOfService);
         }
     }
 }

--- a/src/Magus.Bot/Modules/ModuleBase.cs
+++ b/src/Magus.Bot/Modules/ModuleBase.cs
@@ -15,7 +15,7 @@ namespace Magus.Bot.Modules
     /// </remarks>
     public abstract class ModuleBase : InteractionModuleBase<SocketInteractionContext> // InteractionService will log a warning "not public" (as of v3.8) as the class is abstract. Ignore
     {
-        static readonly string version = Assembly.GetEntryAssembly()!.GetName().Version!.ToString();
+        static readonly string version = Assembly.GetEntryAssembly()!.GetName().Version!.ToString(3);
 
         protected ModuleBase()
         {

--- a/src/Magus.Bot/Modules/ModuleBase.cs
+++ b/src/Magus.Bot/Modules/ModuleBase.cs
@@ -25,7 +25,8 @@ namespace Magus.Bot.Modules
         [SlashCommand("help", "Get help with these commands")]
         public async Task Help()
         {
-            await RespondAsync(embed: await CreateHelpEmbed(Context, GetType()), ephemeral: true);
+            await DeferAsync();
+            await FollowupAsync(embed: await CreateHelpEmbed(Context, GetType()), ephemeral: true);
         }
 
         internal static async Task<Embed> CreateHelpEmbed(SocketInteractionContext context, Type type)

--- a/src/Magus.Bot/Modules/PatchNoteModule.cs
+++ b/src/Magus.Bot/Modules/PatchNoteModule.cs
@@ -7,7 +7,7 @@ using Magus.Data.Models.Embeds;
 
 namespace Magus.Bot.Modules
 {
-    [Group("patch", "Knowledge 📚")]
+    [Group("patch", "Get specific patchnotes for any patch! ... *since 7.06d*.")]
     [ModuleRegistration(Location.GLOBAL)]
     public class PatchNoteModule : ModuleBase
     {
@@ -20,11 +20,11 @@ namespace Magus.Bot.Modules
 
         [SlashCommand("when", "how long is a piece of string?")]
         public async Task When()
-            => await RespondAsync("After a new patch is announced, it may take around ~30-60 minutes for me to fully update depending on different factors.\nIf they make breaking changes in game files it will take longer.");
+            => await RespondAsync("After a new patch is announced, it may take around ~30-60 minutes for me to fully update depending on different factors.\nIf they make breaking changes in game files it will take longer.\nIf they patch after midnight UTC... I'm sleeping 😅.");
 
-        [SlashCommand("notes", "Knowledge 📚")]
-        public async Task PatchNotes([Summary(description: "The specific patch to lookup")][Autocomplete(typeof(PatchAutocompleteHandler))] string? number = null,
-                                     [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
+        [SlashCommand("notes", "Get General Patchnotes.")]
+        public async Task PatchNotes([Summary(description: "The specific patch to lookup. Otherwise defaults to latest.")][Autocomplete(typeof(PatchAutocompleteHandler))] string? number = null,
+                                     [Summary(description: "The language/locale of the response.")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
             await DeferAsync();
 
@@ -34,10 +34,10 @@ namespace Magus.Bot.Modules
             if (patchNote != null)
                 await FollowupAsync(embed: patchNote.Embed.CreateDiscordEmbed());
             else
-                await FollowupAsync($"Could not find a patch note numbered **{number}**");
+                await FollowupAsync($"Could not find a patch note numbered **{number}**.");
         }
 
-        [SlashCommand("item", "NullReferenceException Talisman")]
+        [SlashCommand("item", "Get an item's last few patchnotes.")]
         public async Task PatchItem([Summary(description: "The item's name to lookup")][Autocomplete(typeof(ItemAutocompleteHandler))] string name,
                                     [Summary(description: "The specific patch to lookup")][Autocomplete(typeof(PatchAutocompleteHandler))] string? patch = null,
                                     [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
@@ -55,7 +55,7 @@ namespace Magus.Bot.Modules
             await FollowupAsync(embeds: embeds.Reverse().ToArray());
         }
 
-        [SlashCommand("hero", "🎶 I need a hero 🎶")]
+        [SlashCommand("hero", "Get the latest patchnote for a hero.")]
         public async Task PatchHero([Summary(description: "The heroes name to lookup")][Autocomplete(typeof(HeroAutocompleteHandler))] string name,
                                     [Summary(description: "The specific patch to lookup")][Autocomplete(typeof(PatchAutocompleteHandler))] string? patch = null,
                                     [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)

--- a/src/Magus.Bot/Modules/PatchNoteModule.cs
+++ b/src/Magus.Bot/Modules/PatchNoteModule.cs
@@ -26,11 +26,12 @@ namespace Magus.Bot.Modules
         public async Task PatchNotes([Summary(description: "The specific patch to lookup")][Autocomplete(typeof(PatchAutocompleteHandler))] string number,
                                      [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
+            await DeferAsync();
             var patchNote = await _db.GetGeneralPatchNote(number, locale ?? Context.Interaction.UserLocale);
             if (patchNote != null)
-                await RespondAsync(embed: patchNote.Embed.CreateDiscordEmbed());
+                await FollowupAsync(embed: patchNote.Embed.CreateDiscordEmbed());
             else
-                await RespondAsync($"Could not find a patch note numbered **{number}**");
+                await FollowupAsync($"Could not find a patch note numbered **{number}**");
         }
 
         [SlashCommand("item", "NullReferenceException Talisman")]
@@ -38,13 +39,14 @@ namespace Magus.Bot.Modules
                                     [Summary(description: "The specific patch to lookup")][Autocomplete(typeof(PatchAutocompleteHandler))] string? patch = null,
                                     [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
+            await DeferAsync();
             var embeds = await GetEntityPatchNotesEmbeds<ItemPatchNoteEmbed>(name, patch, locale, 3);
             if (!embeds.Any())
             {
-                await RespondAsync($"No changes for this item in Patch **{patch}**", ephemeral: true);
+                await FollowupAsync($"No changes for this item in Patch **{patch}**", ephemeral: true);
                 return;
             }
-            await RespondAsync(embeds: embeds.Reverse().ToArray());
+            await FollowupAsync(embeds: embeds.Reverse().ToArray());
         }
 
         [SlashCommand("hero", "🎶 I need a hero 🎶")]
@@ -52,13 +54,14 @@ namespace Magus.Bot.Modules
                                     [Summary(description: "The specific patch to lookup")][Autocomplete(typeof(PatchAutocompleteHandler))] string? patch = null,
                                     [Summary(description: "The language/locale of the response")][Autocomplete(typeof(LocaleAutocompleteHandler))] string? locale = null)
         {
+            await DeferAsync();
             var embeds = await GetEntityPatchNotesEmbeds<HeroPatchNoteEmbed>(name, patch, locale);
             if (!embeds.Any())
             {
-                await RespondAsync($"No changes for this hero in Patch **{patch}**", ephemeral: true);
+                await FollowupAsync($"No changes for this hero in Patch **{patch}**", ephemeral: true);
                 return;
             }
-            await RespondAsync(embeds: embeds.ToArray());
+            await FollowupAsync(embeds: embeds.ToArray());
         }
 
         private async Task<IEnumerable<Discord.Embed>> GetEntityPatchNotesEmbeds<T>(string name, string? patch = null, string? locale = null, int limit = 1) where T : EntityPatchNoteEmbed


### PR DESCRIPTION
Due to latest discord bug breaking images in embeds, workaround is to defer then followup, which is probably a more reliable pattern to use anyway (which was used for config module already), so I have made the changes now for the other commands.

Also improved some command descriptions to be more descriptive and helpful